### PR TITLE
Moe Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ the exact same string that Velocity produces. If not, that is a bug.
 EscapeVelocity has no facilities for HTML escaping and it is not appropriate for producing
 HTML output that might include portions of untrusted input.
 
-<!-- MOE:begin_strip -->
-[TOC]
-<!-- MOE:end_strip -->
 
 ## Motivation
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.36</version>
+      <version>0.44</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/google/escapevelocity/DirectiveNode.java
+++ b/src/main/java/com/google/escapevelocity/DirectiveNode.java
@@ -122,7 +122,7 @@ abstract class DirectiveNode extends Node {
       }
       Runnable undo = context.setVar(var, null);
       StringBuilder sb = new StringBuilder();
-      Iterator<?> it = iterable.iterator();
+      CountingIterator it = new CountingIterator(iterable.iterator());
       Runnable undoForEach = context.setVar("foreach", new ForEachVar(it));
       while (it.hasNext()) {
         context.setVar(var, it.next());
@@ -133,20 +133,49 @@ abstract class DirectiveNode extends Node {
       return sb.toString();
     }
 
+    private static class CountingIterator implements Iterator<Object> {
+      private final Iterator<?> iterator;
+      private int index = -1;
+
+      CountingIterator(Iterator<?> iterator) {
+        this.iterator = iterator;
+      }
+
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public Object next() {
+        Object next = iterator.next();
+        index++;
+        return next;
+      }
+
+      int index() {
+        return index;
+      }
+    }
+
     /**
      *  This class is the type of the variable {@code $foreach} that is defined within
      * {@code #foreach} loops. Its {@link #getHasNext()} method means that we can write
-     * {@code #if ($foreach.hasNext)}.
+     * {@code #if ($foreach.hasNext)} and likewise for {@link #getIndex()}.
      */
     private static class ForEachVar {
-      private final Iterator<?> iterator;
+      private final CountingIterator iterator;
 
-      ForEachVar(Iterator<?> iterator) {
+      ForEachVar(CountingIterator iterator) {
         this.iterator = iterator;
       }
 
       public boolean getHasNext() {
         return iterator.hasNext();
+      }
+
+      public int getIndex() {
+        return iterator.index();
       }
     }
   }

--- a/src/main/java/com/google/escapevelocity/EvaluationContext.java
+++ b/src/main/java/com/google/escapevelocity/EvaluationContext.java
@@ -15,6 +15,8 @@
  */
 package com.google.escapevelocity;
 
+import com.google.common.collect.ImmutableSet;
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -40,11 +42,16 @@ interface EvaluationContext {
    */
   Runnable setVar(final String var, Object value);
 
+  /** See {@link MethodFinder#publicMethodsWithName}. */
+  ImmutableSet<Method> publicMethodsWithName(Class<?> startClass, String name);
+
   class PlainEvaluationContext implements EvaluationContext {
     private final Map<String, Object> vars;
+    private final MethodFinder methodFinder;
 
-    PlainEvaluationContext(Map<String, ?> vars) {
-      this.vars = new TreeMap<String, Object>(vars);
+    PlainEvaluationContext(Map<String, ?> vars, MethodFinder methodFinder) {
+      this.vars = new TreeMap<>(vars);
+      this.methodFinder = methodFinder;
     }
 
     @Override
@@ -68,6 +75,11 @@ interface EvaluationContext {
       }
       vars.put(var, value);
       return undo;
+    }
+
+    @Override
+    public ImmutableSet<Method> publicMethodsWithName(Class<?> startClass, String name) {
+      return methodFinder.publicMethodsWithName(startClass, name);
     }
   }
 }

--- a/src/main/java/com/google/escapevelocity/EvaluationException.java
+++ b/src/main/java/com/google/escapevelocity/EvaluationException.java
@@ -29,6 +29,6 @@ public class EvaluationException extends RuntimeException {
   }
 
   EvaluationException(String message, Throwable cause) {
-    super(cause);
+    super(message, cause);
   }
 }

--- a/src/main/java/com/google/escapevelocity/Macro.java
+++ b/src/main/java/com/google/escapevelocity/Macro.java
@@ -17,10 +17,11 @@ package com.google.escapevelocity;
 
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
 
 /**
  * A macro definition. Macros appear in templates using the syntax {@code #macro (m $x $y) ... #end}
@@ -130,6 +131,11 @@ class Macro {
           parameterThunks.put(var, thunk);
         };
       }
+    }
+
+    @Override
+    public ImmutableSet<Method> publicMethodsWithName(Class<?> startClass, String name) {
+      return originalEvaluationContext.publicMethodsWithName(startClass, name);
     }
   }
 }

--- a/src/main/java/com/google/escapevelocity/MethodFinder.java
+++ b/src/main/java/com/google/escapevelocity/MethodFinder.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.escapevelocity;
+
+import static com.google.common.reflect.Reflection.getPackageName;
+import static java.util.stream.Collectors.toSet;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Table;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Finds public methods in a class. For each one, it determines the public class or interface in
+ * which it is declared. This avoids a problem with reflection, where we get an exception if we call
+ * a {@code Method} in a non-public class, even if the {@code Method} is public and if there is a
+ * public ancestor class or interface that declares it. We need to use the {@code Method} from the
+ * public ancestor.
+ *
+ * <p>Because looking for these methods is relatively expensive, an instance of this class will keep
+ * a cache of methods it previously discovered.
+ */
+class MethodFinder {
+
+  /**
+   * For a given class and name, returns all public methods of that name in the class, as previously
+   * determined by {@link #publicMethodsWithName}. The set of methods for a given class and name is
+   * saved the first time it is searched for, and returned directly thereafter. It may be empty.
+   *
+   * <p>Currently we add the entry for any given (class, name) pair on demand. An alternative would
+   * be to add all the methods for a given class at once. With the current scheme, we may end up
+   * calling {@link Class#getMethods()} several times for the same class, if methods of the
+   * different names are called at different times. With an all-at-once scheme, we might end up
+   * computing and storing information about a bunch of methods that will never be called. Because
+   * the profiling that led to the creation of this class revealed that {@link #visibleMethods} in
+   * particular is quite expensive, it's probably best to avoid calling it unnecessarily.
+   */
+  private final Table<Class<?>, String, ImmutableSet<Method>> methodCache = HashBasedTable.create();
+
+  /**
+   * Returns the set of public methods with the given name in the given class. Here, "public
+   * methods" means public methods in public classes or interfaces. If {@code startClass} is not
+   * itself public, its methods are effectively not public either, but inherited methods may still
+   * appear in the returned set, with the {@code Method} objects belonging to public ancestors. More
+   * than one ancestor may define an appropriate method, but it doesn't matter because invoking any
+   * of those {@code Method} objects will have the same effect.
+   */
+  synchronized ImmutableSet<Method> publicMethodsWithName(Class<?> startClass, String name) {
+    ImmutableSet<Method> cachedMethods = methodCache.get(startClass, name);
+    if (cachedMethods == null) {
+      cachedMethods = uncachedPublicMethodsWithName(startClass, name);
+      methodCache.put(startClass, name, cachedMethods);
+    }
+    return cachedMethods;
+  }
+
+  private ImmutableSet<Method> uncachedPublicMethodsWithName(Class<?> startClass, String name) {
+    // Class.getMethods() only returns public methods, so no need to filter explicitly for public.
+    Set<Method> methods =
+        Arrays.stream(startClass.getMethods())
+            .filter(m -> m.getName().equals(name))
+            .collect(toSet());
+    if (!classIsPublic(startClass)) {
+      methods =
+          methods.stream()
+              .map(m -> visibleMethod(m, startClass))
+              .filter(Objects::nonNull)
+              .collect(toSet());
+      // It would be a bit simpler to use ImmutableSet.toImmutableSet() here, but there've been
+      // problems in the past with versions of Guava that don't have that method.
+    }
+    return ImmutableSet.copyOf(methods);
+  }
+
+  private static final String THIS_PACKAGE = getPackageName(Node.class) + ".";
+
+  /**
+   * Returns a Method with the same name and parameter types as the given one, but that is in a
+   * public class or interface. This might be the given method, or it might be a method in a
+   * superclass or superinterface.
+   *
+   * @return a public method in a public class or interface, or null if none was found.
+   */
+  static Method visibleMethod(Method method, Class<?> in) {
+    if (in == null) {
+      return null;
+    }
+    Method methodInClass;
+    try {
+      methodInClass = in.getMethod(method.getName(), method.getParameterTypes());
+    } catch (NoSuchMethodException e) {
+      return null;
+    }
+    if (classIsPublic(in) || in.getName().startsWith(THIS_PACKAGE)) {
+      // The second disjunct is a hack to allow us to use the public methods of $foreach without
+      // having to make the ForEachVar class public. We can invoke those methods from the same
+      // package since ForEachVar is package-protected.
+      return methodInClass;
+    }
+    Method methodInSuperclass = visibleMethod(method, in.getSuperclass());
+    if (methodInSuperclass != null) {
+      return methodInSuperclass;
+    }
+    for (Class<?> superinterface : in.getInterfaces()) {
+      Method methodInSuperinterface = visibleMethod(method, superinterface);
+      if (methodInSuperinterface != null) {
+        return methodInSuperinterface;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns whether the given class is public as seen from this class. Prior to Java 9, a class was
+   * either public or not public. But with the introduction of modules in Java 9, a class can be
+   * marked public and yet not be visible, if it is not exported from the module it appears in. So,
+   * on Java 9, we perform an additional check on class {@code c}, which is effectively {@code
+   * c.getModule().isExported(c.getPackageName())}. We use reflection so that the code can compile
+   * on earlier Java versions.
+   */
+  private static boolean classIsPublic(Class<?> c) {
+    return Modifier.isPublic(c.getModifiers()) && classIsExported(c);
+  }
+
+  private static boolean classIsExported(Class<?> c) {
+    if (CLASS_GET_MODULE_METHOD == null) {
+      return true; // There are no modules, so all classes are exported.
+    }
+    try {
+      String pkg = getPackageName(c);
+      Object module = CLASS_GET_MODULE_METHOD.invoke(c);
+      return (Boolean) MODULE_IS_EXPORTED_METHOD.invoke(module, pkg);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static final Method CLASS_GET_MODULE_METHOD;
+  private static final Method MODULE_IS_EXPORTED_METHOD;
+
+  static {
+    Method classGetModuleMethod;
+    Method moduleIsExportedMethod;
+    try {
+      classGetModuleMethod = Class.class.getMethod("getModule");
+      Class<?> moduleClass = classGetModuleMethod.getReturnType();
+      moduleIsExportedMethod = moduleClass.getMethod("isExported", String.class);
+    } catch (Exception e) {
+      classGetModuleMethod = null;
+      moduleIsExportedMethod = null;
+    }
+    CLASS_GET_MODULE_METHOD = classGetModuleMethod;
+    MODULE_IS_EXPORTED_METHOD = moduleIsExportedMethod;
+  }
+}

--- a/src/main/java/com/google/escapevelocity/Node.java
+++ b/src/main/java/com/google/escapevelocity/Node.java
@@ -64,7 +64,6 @@ abstract class Node {
     return new Cons(resourceName, lineNumber, ImmutableList.<Node>of());
   }
 
-
   /**
    * Create a new parse tree node that is the concatenation of the given ones. Evaluating the
    * new node produces the same string as evaluating each of the given nodes and concatenating the

--- a/src/test/java/com/google/escapevelocity/MethodFinderTest.java
+++ b/src/test/java/com/google/escapevelocity/MethodFinderTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.escapevelocity;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.stream.Collectors.toSet;
+
+import com.google.common.collect.ImmutableMap;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MethodFinderTest {
+  @Test
+  public void visibleMethodFromClass() throws Exception {
+    Map<String, String> map = Collections.singletonMap("foo", "bar");
+    Class<?> mapClass = map.getClass();
+    assertThat(Modifier.isPublic(mapClass.getModifiers())).isFalse();
+    
+    Method size = mapClass.getMethod("size");
+    Method visibleSize = MethodFinder.visibleMethod(size, mapClass);
+    assertThat(visibleSize.getDeclaringClass().isInterface()).isFalse();
+    assertThat(visibleSize.invoke(map)).isEqualTo(1);
+  }
+
+  @Test
+  public void visibleMethodFromInterface() throws Exception {
+    Map<String, String> map = ImmutableMap.of("foo", "bar");
+    Map.Entry<String, String> entry = map.entrySet().iterator().next();
+    Class<?> entryClass = entry.getClass();
+    assertThat(Modifier.isPublic(entryClass.getModifiers())).isFalse();
+    
+    Method getValue = entryClass.getMethod("getValue");
+    Method visibleGetValue = MethodFinder.visibleMethod(getValue, entryClass);
+    assertThat(visibleGetValue.getDeclaringClass().isInterface()).isTrue();
+    assertThat(visibleGetValue.invoke(entry)).isEqualTo("bar");
+  }
+
+  @Test
+  public void publicMethodsWithName() {
+    List<String> list = Collections.singletonList("foo");
+    Class<?> listClass = list.getClass();
+    assertThat(Modifier.isPublic(listClass.getModifiers())).isFalse();
+    
+    MethodFinder methodFinder = new MethodFinder();
+    Set<Method> methods = methodFinder.publicMethodsWithName(listClass, "remove");
+    // This should find at least remove(int) and remove(Object).
+    assertThat(methods.size()).isAtLeast(2);
+    assertThat(methods.stream().map(Method::getName).collect(toSet())).containsExactly("remove");
+    assertThat(methods.stream().allMatch(MethodFinderTest::isPublic)).isTrue();
+    
+    // We should cache the result, meaning we get back the same result if we ask a second time.
+    Set<Method> methods2 = methodFinder.publicMethodsWithName(listClass, "remove");
+    assertThat(methods2).isSameInstanceAs(methods);
+  }
+
+  @Test
+  public void publicMethodsWithName_Nonexistent() {
+    List<String> list = Collections.singletonList("foo");
+    Class<?> listClass = list.getClass();
+    assertThat(Modifier.isPublic(listClass.getModifiers())).isFalse();
+    
+    MethodFinder methodFinder = new MethodFinder();
+    Set<Method> methods = methodFinder.publicMethodsWithName(listClass, "nonexistentMethod");
+    assertThat(methods).isEmpty();
+  }
+
+  private static boolean isPublic(Method method) {
+    return Modifier.isPublic(method.getModifiers())
+        && Modifier.isPublic(method.getDeclaringClass().getModifiers());
+  }
+}

--- a/src/test/java/com/google/escapevelocity/ReferenceNodeTest.java
+++ b/src/test/java/com/google/escapevelocity/ReferenceNodeTest.java
@@ -17,15 +17,11 @@ package com.google.escapevelocity;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.escapevelocity.ReferenceNode.MethodReferenceNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Primitives;
 import com.google.common.truth.Expect;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.Collections;
-import java.util.Map;
+import com.google.escapevelocity.ReferenceNode.MethodReferenceNode;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,19 +81,9 @@ public class ReferenceNodeTest {
             MethodReferenceNode.primitiveTypeIsAssignmentCompatible(to, from);
         expect
             .withMessage(from + " assignable to " + to)
-            .that(expected).isEqualTo(actual);
+            .that(actual).isEqualTo(expected);
       }
     }
-  }
-
-  @Test
-  public void testVisibleMethod() throws Exception {
-    Map<String, String> map = Collections.singletonMap("foo", "bar");
-    Class<?> mapClass = map.getClass();
-    assertThat(Modifier.isPublic(mapClass.getModifiers())).isFalse();
-    Method size = map.getClass().getMethod("size");
-    Method visibleSize = ReferenceNode.visibleMethod(size, mapClass);
-    assertThat(visibleSize.invoke(map)).isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Sync from internal

---

Cache Method objects per template rather than per template evaluation.

In a somewhat artificial benchmark, this sped up evaluation by 35%. The benchmark compiles AutoValueTest.java 100 times, and measures how much time was spent by AutoValueProcessor in template evaluation. AutoValueTest.java has 40 @AutoValue classes, and each of those triggers a separate template evaluation. Previously every one of those created a new Method cache (MethodFinder object). Now only the first one (on each iteration of the benchmark) does.

Compilation runs will rarely have as many as 40 @AutoValue classes, but they have often have several, so there is still some benefit.

According to this benchmark, EscapeVelocity and Apache Velocity now have indistinguishable performance.

Internal change: 245835876

---

Avoid excessive reflection overhead by caching the results of method lookups. On an ad-hoc benchmark this improved template evaluation time by 38%. That means that code generators such as AutoValue that use EscapeVelocity should see a substantial speedup.

Internal change: 244671738

---

If $foo is a Map then Velocity interprets $foo.bar the same as $foo["bar"]. Previously EscapeVelocity interpreted it the same as for other objects, by looking for a getBar() method (or boolean isBar()).

b515e83e6e713ff7ae6035c181b968ed67cb59db